### PR TITLE
Remove the SoaSort class and move the functions to the namespace.

### DIFF
--- a/src/example.cc
+++ b/src/example.cc
@@ -19,9 +19,9 @@ int main()
   std::vector<char> char_vector = { 'd', 'c', 'f', 'e', 'a', 'b' };
   auto cmp = [](const int& a, const int& b) { return a > b; };
 
-  soa::SoaSort::sort<decltype(test.begin())>(
-  test.begin(), test.end(), second_vector.begin(), third_vector.begin(),
-  char_vector.begin());
+  soa_sort::sort<decltype(test.begin())>(
+      test.begin(), test.end(), second_vector.begin(), third_vector.begin(),
+      char_vector.begin());
 
   // Print the sorted test vector and the other 2 dependent_vectors.
   std::cout << "first vector: "

--- a/src/soa_sort.h
+++ b/src/soa_sort.h
@@ -6,64 +6,13 @@
 #include <numeric>
 #include <thread>
 #include <vector>
-namespace soa {
-class SoaSort {
-  static constexpr bool THREADING = true;
+namespace soa_sort {
 
-public:
-  SoaSort() = delete;
+constexpr bool THREADING = true;
+namespace {
 
-  // Sort the elements in range [first, last) in ascending order.
-  // Apply the permutation determined by the [first, last) sort order to the remaining iterators 
-  // given by args.
-  //
-  // The parameters first, last determine the range of elements to sort.
-  // The value of the elements from [first, last) determine the permutation which is then applied 
-  // to the remaining args.
-  //
-  // The args are iterators which point to starting point where the permutation will be applied.
-  template <class Iterator, class... Iterators>
-  static void sort(Iterator first, Iterator last, Iterators... args)
-  {
-    auto cmp = [](const decltype(*first)& a, const decltype(*first)& b) {
-      return a < b;
-    };
-
-    sort_cmp(first, last, cmp, args...);
-  }
-
-  // Sort the elements in range [first, last) with a custom comparator.
-  // Apply the permutation determined by the [first, last) sort order to the remaining iterators 
-  // given by args.
-  //
-  // First and last determine the range of elements to sort.
-  // The value of the elements from [first, last) determine the permutation which is 
-  // then applied to the remaining args.
-  //
-  // The args are iterators which point to starting point where the permutation will be applied.
-  template <class Iterator, class... Iterators>
-  static void sort_cmp(
-      Iterator first, Iterator last,
-      const std::function<bool(const decltype(*first)& a, const decltype(*first)& b)>&
-          cmp,
-      Iterators... args)
-  {
-    std::vector<int> indices(std::distance(first, last));
-    std::iota(indices.begin(), indices.end(), 0);
-
-    // Sort the indices using the values found in the first iterator.
-    std::sort(indices.begin(), indices.end(),
-        [first, cmp](const int& a, const int& b) {
-          return cmp(*(first + a), *(first + b));
-        });
-
-    // Apply the calculated permutation to all other iterators.
-    sort(indices, first, args...);
-  }
-
-private:
   template <class Iterator>
-  static void apply_permutation(const std::vector<int>& indices,
+  void apply_permutation(const std::vector<int>& indices,
       Iterator first)
   {
 
@@ -85,17 +34,17 @@ private:
 
   // Base case for parameter packing.
   template <class Iterator>
-  static void sort(const std::vector<int>& indices, Iterator it)
+  void sort(const std::vector<int>& indices, Iterator it)
   {
     apply_permutation(indices, it);
   }
 
   // Start a new thread for every apply permutation.
   template <class Iterator, class... Iterators>
-  static void sort(const std::vector<int>& indices, Iterator i1,
+  void sort(const std::vector<int>& indices, Iterator i1,
       Iterators... args)
   {
-    if (SoaSort::THREADING) {
+    if (THREADING) {
       std::thread t1(apply_permutation<Iterator>, indices, i1);
       sort(indices, args...);
       t1.join();
@@ -104,7 +53,55 @@ private:
       sort(indices, args...);
     }
   }
-};
+} // namespace
+
+// Sort the elements in range [first, last) with a custom comparator.
+// Apply the permutation determined by the [first, last) sort order to the remaining iterators
+// given by args.
+//
+// First and last determine the range of elements to sort.
+// The value of the elements from [first, last) determine the permutation which is
+// then applied to the remaining args.
+//
+// The args are iterators which point to starting point where the permutation will be applied.
+template <class Iterator, class... Iterators>
+void sort_cmp(
+    Iterator first, Iterator last,
+    const std::function<bool(const decltype(*first)& a, const decltype(*first)& b)>&
+        cmp,
+    Iterators... args)
+{
+  std::vector<int> indices(std::distance(first, last));
+  std::iota(indices.begin(), indices.end(), 0);
+
+  // Sort the indices using the values found in the first iterator.
+  std::sort(indices.begin(), indices.end(),
+      [first, cmp](const int& a, const int& b) {
+        return cmp(*(first + a), *(first + b));
+      });
+
+  // Apply the calculated permutation to all other iterators.
+  sort(indices, first, args...);
+}
+
+// Sort the elements in range [first, last) in ascending order.
+// Apply the permutation determined by the [first, last) sort order to the remaining iterators
+// given by args.
+//
+// The parameters first, last determine the range of elements to sort.
+// The value of the elements from [first, last) determine the permutation which is then applied
+// to the remaining args.
+//
+// The args are iterators which point to starting point where the permutation will be applied.
+template <class Iterator, class... Iterators>
+void sort(Iterator first, Iterator last, Iterators... args)
+{
+  auto cmp = [](const decltype(*first)& a, const decltype(*first)& b) {
+    return a < b;
+  };
+
+  sort_cmp(first, last, cmp, args...);
+}
 
 } // namespace soa
-#endif
+#endif // SOASORT_H

--- a/tests/particles.cc
+++ b/tests/particles.cc
@@ -4,8 +4,8 @@
 #include <exception>
 #include <fstream>
 #include <iostream>
-#include <string>
 #include <random>
+#include <string>
 
 using size_type = std::vector<char>::size_type;
 
@@ -119,7 +119,7 @@ int main()
       std::cout << "Sorting by position x coordinate" << std::endl;
 
       auto start = std::chrono::high_resolution_clock::now();
-      soa::SoaSort::sort_cmp(
+      soa_sort::sort_cmp(
           particles.positions.begin(), particles.positions.end(),
           [](const auto& a, const auto& b) { return a.x < b.x; },
           particles.masses.begin(), particles.colors.begin(), particles.velocities.begin());
@@ -134,7 +134,7 @@ int main()
       std::cout << "Sorting by velocity y value" << std::endl;
 
       auto start = std::chrono::high_resolution_clock::now();
-      soa::SoaSort::sort_cmp(
+      soa_sort::sort_cmp(
           particles.velocities.begin(), particles.velocities.end(),
           [](const auto& a, const auto& b) { return a.y < b.y; },
           particles.masses.begin(), particles.colors.begin(), particles.positions.begin());
@@ -149,7 +149,7 @@ int main()
       std::cout << "Sorting by mass" << std::endl;
 
       auto start = std::chrono::high_resolution_clock::now();
-      soa::SoaSort::sort(
+      soa_sort::sort(
           particles.masses.begin(), particles.masses.end(),
           particles.positions.begin(), particles.colors.begin(), particles.velocities.begin());
       auto finish = std::chrono::high_resolution_clock::now();
@@ -162,7 +162,7 @@ int main()
       std::cout << "Sorting by color alpha value" << std::endl;
 
       auto start = std::chrono::high_resolution_clock::now();
-      soa::SoaSort::sort_cmp(
+      soa_sort::sort_cmp(
           particles.colors.begin(), particles.colors.end(),
           [](const auto& a, const auto& b) { return a.a < b.a; },
           particles.positions.begin(), particles.masses.begin(), particles.velocities.begin());

--- a/tests/unit_test.cc
+++ b/tests/unit_test.cc
@@ -12,7 +12,7 @@ TEST(SoaSortTest, EmptyIndependentAndEmptyDependent)
   std::vector<int> actual_dependent = {};
 
   // Sort
-  soa::SoaSort::sort<decltype(actual_independent.begin())>(
+  soa_sort::sort<decltype(actual_independent.begin())>(
       actual_independent.begin(), actual_independent.end(),
       actual_dependent.begin());
 
@@ -30,7 +30,7 @@ TEST(SoaSortTest, SingleIntIndependentAndSingleIntDependent)
   std::vector<int> actual_dependent = { 3, 4, 1, 2, 5 };
 
   // Sort
-  soa::SoaSort::sort<>(
+  soa_sort::sort<>(
       actual_independent.begin(), actual_independent.end(),
       actual_dependent.begin());
 
@@ -47,7 +47,7 @@ TEST(SoaSortTest, Test2IntArrays)
   int actual_dependent[5] = { 3, 4, 1, 2, 5 };
 
   // Sort
-  soa::SoaSort::sort<decltype(std::begin(actual_independent))>(
+  soa_sort::sort<decltype(std::begin(actual_independent))>(
       std::begin(actual_independent), std::end(actual_independent),
       std::begin(actual_dependent));
 
@@ -65,7 +65,7 @@ TEST(SoaSortTest, Test2IntArraysOneChar)
   int actual_dependent_1[5] = { 'c', 'b', 'e', 'd', 'a' };
 
   // Sort
-  soa::SoaSort::sort<decltype(std::begin(actual_independent))>(
+  soa_sort::sort<decltype(std::begin(actual_independent))>(
       std::begin(actual_independent), std::end(actual_independent),
       std::begin(actual_dependent_0), std::begin(actual_dependent_1));
 


### PR DESCRIPTION
Use namespace functions instead of the current static functions in SoaSort.
An anonymous namespace prevents the previously private functions to be accessed outside of the soa_sort.h file.