### PR TITLE
Use a template parameter instead of std::function for the comparator.

### DIFF
--- a/src/soa_sort.h
+++ b/src/soa_sort.h
@@ -64,11 +64,10 @@ namespace {
 // then applied to the remaining args.
 //
 // The args are iterators which point to starting point where the permutation will be applied.
-template <class Iterator, class... Iterators>
+template <class Iterator, typename Compare, class... Iterators>
 void sort_cmp(
     Iterator first, Iterator last,
-    const std::function<bool(const decltype(*first)& a, const decltype(*first)& b)>&
-        cmp,
+	Compare cmp,
     Iterators... args)
 {
   std::vector<int> indices(std::distance(first, last));


### PR DESCRIPTION
Use a template parameter instead of std::function for the comparator. This improves performance. (Probably has something to do with inlining)