### PR TITLE
Improved parallelization

### DIFF
--- a/src/example.cc
+++ b/src/example.cc
@@ -2,6 +2,7 @@
 #include <algorithm>
 #include <iostream>
 #include <vector>
+
 template <class T>
 void print_vector(const std::vector<T>& vector)
 {
@@ -19,16 +20,14 @@ int main()
   std::vector<char> char_vector = { 'd', 'c', 'f', 'e', 'a', 'b' };
   auto cmp = [](const int& a, const int& b) { return a > b; };
 
-  soa_sort::sort<decltype(test.begin())>(
+  soa_sort::sort<false, decltype(test.begin())>(
       test.begin(), test.end(), second_vector.begin(), third_vector.begin(),
       char_vector.begin());
 
   // Print the sorted test vector and the other 2 dependent_vectors.
-  std::cout << "first vector: "
-            << "\n";
+  std::cout << "first vector: " << std::endl;
   print_vector(test);
-  std::cout << "dependent_vectors: "
-            << "\n";
+  std::cout << "dependent_vectors: " << std::endl;
   print_vector(second_vector);
   print_vector(third_vector);
   print_vector(char_vector);

--- a/src/soa_sort.h
+++ b/src/soa_sort.h
@@ -29,6 +29,8 @@ namespace soa_sort {
 
   template<bool AllowParallelization>
   struct soa_sort_implementation {
+	// Apply a permutation to one iterator.
+	// Each element at position i is moved to indices[i]
     template <class Iterator>
     static void apply_permutation(const std::vector<int>& indices, Iterator begin)
     {
@@ -49,6 +51,7 @@ namespace soa_sort {
       }
     }
 
+	// Base case, apply a permutation to the head element if i == acc, error otherwise
     template <class Head>
     static void apply_permutation_to_ith_iterator(const std::vector<int>& indices, unsigned int i, unsigned int acc, Head head)
     {
@@ -60,6 +63,10 @@ namespace soa_sort {
       }
     }
 
+	// Apply a permutation to the ith element in a list.
+	// If i == acc, then we have reached the target element and apply_permutation is called.
+	// Else, recurse with the tail of the list and incremented acc.
+	// Recursion is used because parameter packs cannot be indexed by a runtime index.
     template <class Head, class... Tail>
     static void apply_permutation_to_ith_iterator(const std::vector<int>& indices, unsigned int i, unsigned int acc, Head head, Tail... tail)
     {
@@ -70,6 +77,7 @@ namespace soa_sort {
       }
     }
 
+	// Apply a permutation to multiple iterators.
     template <class... Iterators>
     static void apply_permutation(const std::vector<int>& indices, Iterators... args)
     {

--- a/tests/particles.cc
+++ b/tests/particles.cc
@@ -1,3 +1,7 @@
+#if __has_include("execution")
+//#define SOASORT_USE_STD_PARALLEL
+#endif // __has_include("execution")
+
 #include "soa_sort.h"
 #include "utility.h"
 #include <chrono>
@@ -119,7 +123,7 @@ int main()
       std::cout << "Sorting by position x coordinate" << std::endl;
 
       auto start = std::chrono::high_resolution_clock::now();
-      soa_sort::sort_cmp(
+      soa_sort::sort_cmp<true>(
           particles.positions.begin(), particles.positions.end(),
           [](const auto& a, const auto& b) { return a.x < b.x; },
           particles.masses.begin(), particles.colors.begin(), particles.velocities.begin());
@@ -134,7 +138,7 @@ int main()
       std::cout << "Sorting by velocity y value" << std::endl;
 
       auto start = std::chrono::high_resolution_clock::now();
-      soa_sort::sort_cmp(
+      soa_sort::sort_cmp<true>(
           particles.velocities.begin(), particles.velocities.end(),
           [](const auto& a, const auto& b) { return a.y < b.y; },
           particles.masses.begin(), particles.colors.begin(), particles.positions.begin());
@@ -149,7 +153,7 @@ int main()
       std::cout << "Sorting by mass" << std::endl;
 
       auto start = std::chrono::high_resolution_clock::now();
-      soa_sort::sort(
+      soa_sort::sort<true>(
           particles.masses.begin(), particles.masses.end(),
           particles.positions.begin(), particles.colors.begin(), particles.velocities.begin());
       auto finish = std::chrono::high_resolution_clock::now();
@@ -162,7 +166,7 @@ int main()
       std::cout << "Sorting by color alpha value" << std::endl;
 
       auto start = std::chrono::high_resolution_clock::now();
-      soa_sort::sort_cmp(
+      soa_sort::sort_cmp<true>(
           particles.colors.begin(), particles.colors.end(),
           [](const auto& a, const auto& b) { return a.a < b.a; },
           particles.positions.begin(), particles.masses.begin(), particles.velocities.begin());

--- a/tests/particles.cc
+++ b/tests/particles.cc
@@ -1,5 +1,5 @@
 #if __has_include("execution")
-//#define SOASORT_USE_STD_PARALLEL
+#define SOASORT_USE_STD_PARALLEL
 #endif // __has_include("execution")
 
 #include "soa_sort.h"

--- a/tests/unit_test.cc
+++ b/tests/unit_test.cc
@@ -13,7 +13,7 @@ TEST(SoaSortTest, EmptyIndependentAndEmptyDependent)
   std::vector<int> actual_dependent = {};
 
   // Sort
-  soa_sort::sort<decltype(actual_independent.begin())>(
+  soa_sort::sort<false, decltype(actual_independent.begin())>(
       actual_independent.begin(), actual_independent.end(),
       actual_dependent.begin());
 
@@ -31,7 +31,7 @@ TEST(SoaSortTest, SingleIntIndependentAndSingleIntDependent)
   std::vector<int> actual_dependent = { 3, 4, 1, 2, 5 };
 
   // Sort
-  soa_sort::sort<>(
+  soa_sort::sort<false>(
       actual_independent.begin(), actual_independent.end(),
       actual_dependent.begin());
 
@@ -48,7 +48,7 @@ TEST(SoaSortTest, Test2IntArrays)
   int actual_dependent[5] = { 3, 4, 1, 2, 5 };
 
   // Sort
-  soa_sort::sort<decltype(std::begin(actual_independent))>(
+  soa_sort::sort<false, decltype(std::begin(actual_independent))>(
       std::begin(actual_independent), std::end(actual_independent),
       std::begin(actual_dependent));
 
@@ -66,7 +66,7 @@ TEST(SoaSortTest, Test2IntArraysOneChar)
   int actual_dependent_1[5] = { 'c', 'b', 'e', 'd', 'a' };
 
   // Sort
-  soa_sort::sort<decltype(std::begin(actual_independent))>(
+  soa_sort::sort<false, decltype(std::begin(actual_independent))>(
       std::begin(actual_independent), std::end(actual_independent),
       std::begin(actual_dependent_0), std::begin(actual_dependent_1));
 
@@ -86,7 +86,7 @@ TEST(SoaSortTest, TestComparator)
 	int actual_dependent[5]   = {  3,  2, 5,  4,  1 };
 	
 	// Sort
-	soa_sort::sort_cmp(
+	soa_sort::sort_cmp<false>(
 		std::begin(actual_independent), std::end(actual_independent), 
 		[&referenced_data](auto a, auto b)
 		{
@@ -109,7 +109,7 @@ TEST(SoaSortTest, TestVectorOfArrays)
 	int actual_dependent[5] = { 3, 2, 5,  4, 1 };
 
 	// Sort
-	soa_sort::sort_cmp(
+	soa_sort::sort_cmp<false>(
 		std::begin(actual_independent), std::end(actual_independent),
 		[&referenced_data](auto a, auto b)
 		{
@@ -132,7 +132,7 @@ TEST(SoaSortTest, TestPartialSort)
 	int actual_dependent[5]   = {  3,  2, 5,  4,  1 };
 
 	// Sort
-	soa_sort::sort_cmp(
+	soa_sort::sort_cmp<false>(
 		std::begin(actual_independent) + 1, std::begin(actual_independent) + 4,
 		[&referenced_data](auto a, auto b)
 		{

--- a/tests/unit_test.cc
+++ b/tests/unit_test.cc
@@ -81,69 +81,69 @@ TEST(SoaSortTest, Test2IntArraysOneChar)
 
 TEST(SoaSortTest, TestComparator)
 {
-	int actual_independent[5] = {  0,  1, 2,  3,  4 };
-	int referenced_data[5]    = { 20, 10, 0, 30, 40 };
-	int actual_dependent[5]   = {  3,  2, 5,  4,  1 };
-	
-	// Sort
-	soa_sort::sort_cmp<false>(
-		std::begin(actual_independent), std::end(actual_independent), 
-		[&referenced_data](auto a, auto b)
-		{
-			return referenced_data[a] < referenced_data[b];
-		},
-		std::begin(actual_dependent));
-
-	int expected_independent[5] = { 2, 1, 0, 3, 4 };
-	int expected_dependent[5]   = { 5, 2, 3, 4, 1 };
-
-	ASSERT_THAT(actual_independent, ::testing::ElementsAreArray(expected_independent));
-	ASSERT_THAT(actual_dependent, ::testing::ElementsAreArray(expected_dependent));
+  int actual_independent[5] = {  0,  1, 2,  3,  4 };
+  int referenced_data[5]    = { 20, 10, 0, 30, 40 };
+  int actual_dependent[5]   = {  3,  2, 5,  4,  1 };
+  
+  // Sort
+  soa_sort::sort_cmp<false>(
+    std::begin(actual_independent), std::end(actual_independent), 
+    [&referenced_data](auto a, auto b)
+    {
+      return referenced_data[a] < referenced_data[b];
+    },
+    std::begin(actual_dependent));
+  
+  int expected_independent[5] = { 2, 1, 0, 3, 4 };
+  int expected_dependent[5]   = { 5, 2, 3, 4, 1 };
+  
+  ASSERT_THAT(actual_independent, ::testing::ElementsAreArray(expected_independent));
+  ASSERT_THAT(actual_dependent, ::testing::ElementsAreArray(expected_dependent));
 }
 
 TEST(SoaSortTest, TestVectorOfArrays)
 {
-	std::vector<std::array<uint32_t, 2>> actual_independent = 
-		{ {0, 100}, {1, 101}, {2, 102},  {3, 103},  {4, 104} };
-	int referenced_data[5] = { 20, 0, 10, 40, 30 };
-	int actual_dependent[5] = { 3, 2, 5,  4, 1 };
-
-	// Sort
-	soa_sort::sort_cmp<false>(
-		std::begin(actual_independent), std::end(actual_independent),
-		[&referenced_data](auto a, auto b)
-		{
-			return referenced_data[a[0]] < referenced_data[b[0]];
-		},
-		std::begin(actual_dependent));
-
-	std::vector<std::array<uint32_t, 2>> expected_independent = 
-		{ {1, 101}, {2, 102}, {0, 100}, {4, 104}, {3, 103} };
-	int expected_dependent[5] = { 2, 5, 3, 1, 4 };
-
-	ASSERT_THAT(actual_independent, ::testing::ElementsAreArray(expected_independent));
-	ASSERT_THAT(actual_dependent, ::testing::ElementsAreArray(expected_dependent));
+  std::vector<std::array<uint32_t, 2>> actual_independent = 
+    { {0, 100}, {1, 101}, {2, 102},  {3, 103},  {4, 104} };
+  int referenced_data[5] = { 20, 0, 10, 40, 30 };
+  int actual_dependent[5] = { 3, 2, 5,  4, 1 };
+  
+  // Sort
+  soa_sort::sort_cmp<false>(
+    std::begin(actual_independent), std::end(actual_independent),
+    [&referenced_data](auto a, auto b)
+    {
+      return referenced_data[a[0]] < referenced_data[b[0]];
+    },
+    std::begin(actual_dependent));
+  
+  std::vector<std::array<uint32_t, 2>> expected_independent = 
+    { {1, 101}, {2, 102}, {0, 100}, {4, 104}, {3, 103} };
+  int expected_dependent[5] = { 2, 5, 3, 1, 4 };
+  
+  ASSERT_THAT(actual_independent, ::testing::ElementsAreArray(expected_independent));
+  ASSERT_THAT(actual_dependent, ::testing::ElementsAreArray(expected_dependent));
 }
 
 TEST(SoaSortTest, TestPartialSort)
 {
-	int actual_independent[5] = {  0,  1, 2,  3,  4 };
-	int referenced_data[5]    = { 20, 10, 0, 30, 15 };
-	int actual_dependent[5]   = {  3,  2, 5,  4,  1 };
-
-	// Sort
-	soa_sort::sort_cmp<false>(
-		std::begin(actual_independent) + 1, std::begin(actual_independent) + 4,
-		[&referenced_data](auto a, auto b)
-		{
-			return referenced_data[a] < referenced_data[b];
-		},
-		std::begin(actual_dependent) + 1);
-
-	int expected_independent[5] = { 0, 2, 1, 3, 4 };
-	int expected_dependent[5]   = { 3, 5, 2, 4, 1 };
-
-	ASSERT_THAT(actual_independent, ::testing::ElementsAreArray(expected_independent));
-	ASSERT_THAT(actual_dependent, ::testing::ElementsAreArray(expected_dependent));
+  int actual_independent[5] = {  0,  1, 2,  3,  4 };
+  int referenced_data[5]    = { 20, 10, 0, 30, 15 };
+  int actual_dependent[5]   = {  3,  2, 5,  4,  1 };
+  
+  // Sort
+  soa_sort::sort_cmp<false>(
+    std::begin(actual_independent) + 1, std::begin(actual_independent) + 4,
+    [&referenced_data](auto a, auto b)
+    {
+      return referenced_data[a] < referenced_data[b];
+    },
+    std::begin(actual_dependent) + 1);
+  
+  int expected_independent[5] = { 0, 2, 1, 3, 4 };
+  int expected_dependent[5]   = { 3, 5, 2, 4, 1 };
+  
+  ASSERT_THAT(actual_independent, ::testing::ElementsAreArray(expected_independent));
+  ASSERT_THAT(actual_dependent, ::testing::ElementsAreArray(expected_dependent));
 }
 } // namespace


### PR DESCRIPTION
This PR enables users to call both parallelized and non-parallelized versions of the algorithm based on a template parameter.
Additionally, when parallelization is enabled, a parallelized sorting algorithm is used, if available. (previously, only the permutation application was parallelized)
Two parallelization providers are implemented: Intel Threading Building Blocks, and the <execution> part of cpp17 std.
Users can choose between these two with a define macro, or serial algorithms are used as a fallback if neither is selected.
Finally, some formatting issues were fixed.